### PR TITLE
feat(framework): improve display UI

### DIFF
--- a/.changeset/lucky-oranges-return.md
+++ b/.changeset/lucky-oranges-return.md
@@ -1,0 +1,5 @@
+---
+"@dotslide/framework": patch
+---
+
+Improve slide controls UI and make UI font explicit (`--ds-font-ui` vs `--ds-font-content`)

--- a/apps/example/src/global.css
+++ b/apps/example/src/global.css
@@ -19,6 +19,6 @@ body {
 }
 
 ds-slideshow {
-    --ds-font-family: var(--font-vollkorn);
+    --ds-font-content: var(--font-vollkorn);
     --ds-font-size-base: var(--text-normal);
 }

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -180,7 +180,7 @@ dotSlide uses CSS custom properties for theming:
 
 ```css
 ds-slideshow {
-  --ds-font-family: system-ui, sans-serif;
+  --ds-font-content: system-ui, sans-serif;
   --ds-slide-bg: white;
   --ds-control-bg: white;
   --ds-control-radius: 9999px;

--- a/packages/framework/src/elements/controls/button.css
+++ b/packages/framework/src/elements/controls/button.css
@@ -1,0 +1,26 @@
+
+ds-button { display: contents; }
+ds-button button {
+  border-radius: var(--ds-control-radius, 9999px);
+  background-color: var(--ds-control-bg, white);
+  padding: 0.5rem;
+  box-shadow: var(--ds-control-shadow, 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1));
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+@media (hover: hover) {
+  ds-button button {
+    background-color: rgba(255, 255, 255, 0.4);
+    box-shadow: none;
+    padding: 0.5rem;
+    transition: background-color 0.2s, box-shadow 0.2s;
+  }
+
+  ds-button button:hover {
+    background-color: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 2px 4px rgb(0 0 0 / 0.1);
+  }
+}

--- a/packages/framework/src/elements/controls/button.ts
+++ b/packages/framework/src/elements/controls/button.ts
@@ -1,20 +1,7 @@
 import { withSlideshowContext } from "../../store/context/slideshow.js";
 import { injectStyles } from "../../utils/styles.js";
 
-const buttonCss = `
-ds-button { display: contents; }
-ds-button button {
-  border-radius: var(--ds-control-radius, 9999px);
-  background-color: var(--ds-control-bg, white);
-  padding: 0.75rem;
-  box-shadow: var(--ds-control-shadow, 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1));
-  border: none;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-`;
+import buttonCss from "./button.css?raw";
 
 injectStyles(buttonCss, "button");
 

--- a/packages/framework/src/elements/controls/overlay.css
+++ b/packages/framework/src/elements/controls/overlay.css
@@ -1,0 +1,14 @@
+
+ds-overlay {
+  position: absolute;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+}
+ds-overlay.padded { padding: var(--ds-overlay-padding, 1rem); }
+ds-overlay.top { top: 0; }
+ds-overlay.bottom { bottom: 0; }
+ds-overlay.vcenter { height: 100%; align-items: center; }
+ds-overlay.left { left: 0; }
+ds-overlay.hcenter { width: 100%; justify-content: center; }
+ds-overlay.right { right: 0; }

--- a/packages/framework/src/elements/controls/overlay.ts
+++ b/packages/framework/src/elements/controls/overlay.ts
@@ -1,20 +1,6 @@
 import { injectStyles } from "../../utils/styles.js";
 
-const overlayCss = `
-ds-overlay {
-  position: absolute;
-  display: flex;
-  flex-direction: row;
-  gap: 0.5rem;
-}
-ds-overlay.padded { padding: var(--ds-overlay-padding, 1rem); }
-ds-overlay.top { top: 0; }
-ds-overlay.bottom { bottom: 0; }
-ds-overlay.vcenter { height: 100%; align-items: center; }
-ds-overlay.left { left: 0; }
-ds-overlay.hcenter { width: 100%; justify-content: center; }
-ds-overlay.right { right: 0; }
-`;
+import overlayCss from "./overlay.css?raw";
 
 injectStyles(overlayCss, "overlay");
 

--- a/packages/framework/src/elements/controls/slide-controls.css
+++ b/packages/framework/src/elements/controls/slide-controls.css
@@ -10,7 +10,7 @@
   background-color: rgba(0, 0, 0, 0.5);
   border-radius: 9999px;
   padding: .25rem .75rem;
-  font-family: system-ui, sans-serif;
+  font-family: var(--ds-font-ui, system-ui, sans-serif);
 }
 
 ds-slide-controls {

--- a/packages/framework/src/elements/controls/slide-controls.css
+++ b/packages/framework/src/elements/controls/slide-controls.css
@@ -1,0 +1,41 @@
+
+.controls-left {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.slide-number {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.8);
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 9999px;
+  padding: .25rem .75rem;
+  font-family: system-ui, sans-serif;
+}
+
+ds-slide-controls {
+  opacity: 0;
+  transition: opacity 0.3s;
+  pointer-events: none;
+}
+
+ds-slide-controls[data-visible] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+ds-slide-controls > ds-overlay {
+  align-items: center;
+  gap: .75rem;
+  border-radius: 9999px;
+  padding: .5rem;
+  margin: .75rem;
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+@media (hover: none) {
+  ds-slide-controls {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}

--- a/packages/framework/src/elements/controls/slide-controls.css
+++ b/packages/framework/src/elements/controls/slide-controls.css
@@ -14,14 +14,18 @@
 }
 
 ds-slide-controls {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40%;  
   opacity: 0;
   transition: opacity 0.3s;
-  pointer-events: none;
 }
 
-ds-slide-controls[data-visible] {
+ds-slide-controls[data-visible],
+ds-slide-controls:hover {
   opacity: 1;
-  pointer-events: auto;
 }
 
 ds-slide-controls > ds-overlay {
@@ -35,6 +39,7 @@ ds-slide-controls > ds-overlay {
 
 @media (hover: none) {
   ds-slide-controls {
+    height: auto;
     opacity: 1;
     pointer-events: auto;
   }

--- a/packages/framework/src/elements/controls/slide-controls.ts
+++ b/packages/framework/src/elements/controls/slide-controls.ts
@@ -1,24 +1,93 @@
+import { withSlideshowContext } from "../../store/context/slideshow.js";
 import { injectStyles } from "../../utils/styles.js";
 
-const slideControlsCss = `
-/* no extra CSS - uses ds-overlay and ds-button styles */
-`;
+import slideControlsCss from "./slide-controls.css?raw";
 
 injectStyles(slideControlsCss, "slide-controls");
 
 export class SlideControls extends HTMLElement {
+  private _hideTimeout?: number;
+  private _slideshowRoot?: HTMLElement;
+  private _onMouseMove?: () => void;
+  private _onMouseLeave?: () => void;
+  private _unsubscribeContext?: () => void;
+
+  private _show = () => {
+    this.setAttribute("data-visible", "");
+    if (this._hideTimeout) window.clearTimeout(this._hideTimeout);
+    this._hideTimeout = window.setTimeout(this._hide, 2000);
+  };
+
+  private _hide = () => {
+    this.removeAttribute("data-visible");
+    if (this._hideTimeout) {
+      window.clearTimeout(this._hideTimeout);
+      this._hideTimeout = undefined;
+    }
+  };
+
   connectedCallback() {
     if (!this.querySelector("ds-overlay")) {
       this.innerHTML = `
-        <ds-overlay data-location="bottom" data-alignment="left" data-padding>
-          <ds-button data-action="prev">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
-          </ds-button>
-          <ds-button data-action="next">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
-          </ds-button>
+        <ds-overlay data-location="bottom">
+          <div class="controls-left">
+            <ds-button data-action="prev">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            </ds-button>
+            <ds-button data-action="next">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+            </ds-button>
+          </div>
+          <div class="slide-number"></div>
         </ds-overlay>
       `;
+    }
+
+    // Hover-to-reveal on desktop
+    const slideshowRoot = this.closest("ds-slideshow");
+    if (slideshowRoot instanceof HTMLElement) {
+      this._slideshowRoot = slideshowRoot;
+
+      if (window.matchMedia("(hover: hover)").matches) {
+        this._onMouseMove = this._show;
+        this._onMouseLeave = this._hide;
+
+        slideshowRoot.addEventListener("mousemove", this._onMouseMove);
+        slideshowRoot.addEventListener("mouseleave", this._onMouseLeave);
+      }
+    }
+
+    // Slide number rendering
+    withSlideshowContext(this, (ctx) => {
+      const updateSlideNumber = () => {
+        const store = ctx.get();
+        const slideNumberEl = this.querySelector(".slide-number");
+        if (slideNumberEl) {
+          slideNumberEl.textContent = `${store.activeSlide + 1} / ${store.numSlides}`;
+        }
+      };
+
+      updateSlideNumber();
+      this._unsubscribeContext = ctx.subscribe(updateSlideNumber);
+    });
+  }
+
+  disconnectedCallback() {
+    if (this._slideshowRoot) {
+      if (this._onMouseMove) {
+        this._slideshowRoot.removeEventListener("mousemove", this._onMouseMove);
+      }
+      if (this._onMouseLeave) {
+        this._slideshowRoot.removeEventListener("mouseleave", this._onMouseLeave);
+      }
+    }
+
+    if (this._hideTimeout) {
+      window.clearTimeout(this._hideTimeout);
+    }
+
+    if (this._unsubscribeContext) {
+      this._unsubscribeContext();
     }
   }
 }

--- a/packages/framework/src/elements/controls/slide-controls.ts
+++ b/packages/framework/src/elements/controls/slide-controls.ts
@@ -6,16 +6,28 @@ import slideControlsCss from "./slide-controls.css?raw";
 injectStyles(slideControlsCss, "slide-controls");
 
 export class SlideControls extends HTMLElement {
+  private static readonly HIDE_DELAY_MS = 2000;
+
   private _hideTimeout?: number;
-  private _slideshowRoot?: HTMLElement;
-  private _onMouseMove?: () => void;
+  private _onMouseEnter?: () => void;
   private _onMouseLeave?: () => void;
   private _unsubscribeContext?: () => void;
 
   private _show = () => {
     this.setAttribute("data-visible", "");
+    if (this._hideTimeout) {
+      window.clearTimeout(this._hideTimeout);
+      this._hideTimeout = undefined;
+    }
+  };
+
+  private _startHideTimeout = () => {
     if (this._hideTimeout) window.clearTimeout(this._hideTimeout);
-    this._hideTimeout = window.setTimeout(this._hide, 2000);
+    this._hideTimeout = window.setTimeout(() => {
+      if (!this.matches(":hover")) {
+        this._hide();
+      }
+    }, SlideControls.HIDE_DELAY_MS);
   };
 
   private _hide = () => {
@@ -44,17 +56,15 @@ export class SlideControls extends HTMLElement {
     }
 
     // Hover-to-reveal on desktop
-    const slideshowRoot = this.closest("ds-slideshow");
-    if (slideshowRoot instanceof HTMLElement) {
-      this._slideshowRoot = slideshowRoot;
+    if (window.matchMedia("(hover: hover)").matches) {
+      this._onMouseEnter = this._show;
+      this._onMouseLeave = this._startHideTimeout;
 
-      if (window.matchMedia("(hover: hover)").matches) {
-        this._onMouseMove = this._show;
-        this._onMouseLeave = this._hide;
-
-        slideshowRoot.addEventListener("mousemove", this._onMouseMove);
-        slideshowRoot.addEventListener("mouseleave", this._onMouseLeave);
-      }
+      this.addEventListener("mouseenter", this._onMouseEnter);
+      this.addEventListener("mouseleave", this._onMouseLeave);
+    } else {
+      // Touch devices: always visible, no trigger zone needed
+      this._show();
     }
 
     // Slide number rendering
@@ -73,13 +83,12 @@ export class SlideControls extends HTMLElement {
   }
 
   disconnectedCallback() {
-    if (this._slideshowRoot) {
-      if (this._onMouseMove) {
-        this._slideshowRoot.removeEventListener("mousemove", this._onMouseMove);
-      }
-      if (this._onMouseLeave) {
-        this._slideshowRoot.removeEventListener("mouseleave", this._onMouseLeave);
-      }
+    if (this._onMouseEnter) {
+      this.removeEventListener("mouseenter", this._onMouseEnter);
+    }
+
+    if (this._onMouseLeave) {
+      this.removeEventListener("mouseleave", this._onMouseLeave);
     }
 
     if (this._hideTimeout) {

--- a/packages/framework/src/elements/layout/flex.css
+++ b/packages/framework/src/elements/layout/flex.css
@@ -1,0 +1,7 @@
+ds-flex {
+  display: flex;
+  flex-direction: var(--flex-direction, row);
+  justify-content: var(--justify, start);
+  align-items: var(--align, center);
+  gap: var(--gap, .5rem);
+}

--- a/packages/framework/src/elements/layout/flex.ts
+++ b/packages/framework/src/elements/layout/flex.ts
@@ -1,12 +1,7 @@
 import { injectStyles } from "../../utils/styles.js";
 
-const flexCss = `ds-flex {
-  display: flex;
-  flex-direction: var(--flex-direction, row);
-  justify-content: var(--justify, start);
-  align-items: var(--align, center);
-  gap: var(--gap, .5rem);
-}`;
+import flexCss from "./flex.css?raw";
+
 injectStyles(flexCss, "flex");
 
 export class DsFlex extends HTMLElement {

--- a/packages/framework/src/elements/layout/item.css
+++ b/packages/framework/src/elements/layout/item.css
@@ -1,0 +1,1 @@
+ds-item { display: contents; }

--- a/packages/framework/src/elements/layout/item.ts
+++ b/packages/framework/src/elements/layout/item.ts
@@ -1,6 +1,7 @@
 import { injectStyles } from "../../utils/styles.js";
 
-const itemCss = `ds-item { display: contents; }`;
+import itemCss from "./item.css?raw";
+
 injectStyles(itemCss, "item");
 
 export class DsItem extends HTMLElement {}

--- a/packages/framework/src/elements/layout/list-item.css
+++ b/packages/framework/src/elements/layout/list-item.css
@@ -1,0 +1,23 @@
+ds-list-item {
+  display: list-item;
+  list-style: none;
+}
+
+ds-list[data-mode="ordered"] > ds-list-item::before {
+  counter-increment: ds-list;
+  content: counter(ds-list) ".";
+  display: inline-block;
+  width: 1.5em;
+  text-align: right;
+  margin-right: 0.5em;
+  color: var(--ds-list-marker-color, currentColor);
+}
+
+ds-list[data-mode="unordered"] > ds-list-item::before {
+  content: "\2022";
+  display: inline-block;
+  width: 1.5em;
+  text-align: right;
+  margin-right: 0.5em;
+  color: var(--ds-list-marker-color, currentColor);
+}

--- a/packages/framework/src/elements/layout/list-item.ts
+++ b/packages/framework/src/elements/layout/list-item.ts
@@ -1,28 +1,7 @@
 import { injectStyles } from "../../utils/styles.js";
 
-const listItemCss = `ds-list-item {
-  display: list-item;
-  list-style: none;
-}
+import listItemCss from "./list-item.css?raw";
 
-ds-list[data-mode="ordered"] > ds-list-item::before {
-  counter-increment: ds-list;
-  content: counter(ds-list) ".";
-  display: inline-block;
-  width: 1.5em;
-  text-align: right;
-  margin-right: 0.5em;
-  color: var(--ds-list-marker-color, currentColor);
-}
-
-ds-list[data-mode="unordered"] > ds-list-item::before {
-  content: "\\2022";
-  display: inline-block;
-  width: 1.5em;
-  text-align: right;
-  margin-right: 0.5em;
-  color: var(--ds-list-marker-color, currentColor);
-}`;
 injectStyles(listItemCss, "list-item");
 
 export class DsListItem extends HTMLElement {

--- a/packages/framework/src/elements/layout/list.css
+++ b/packages/framework/src/elements/layout/list.css
@@ -1,0 +1,10 @@
+ds-list {
+  display: block;
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+ds-list[data-mode="ordered"] {
+  counter-reset: ds-list calc(var(--ds-list-start, 1) - 1);
+}

--- a/packages/framework/src/elements/layout/list.ts
+++ b/packages/framework/src/elements/layout/list.ts
@@ -1,15 +1,7 @@
 import { injectStyles } from "../../utils/styles.js";
 
-const listCss = `ds-list {
-  display: block;
-  list-style: none;
-  padding-left: 0;
-  margin: 0;
-}
+import listCss from "./list.css?raw";
 
-ds-list[data-mode="ordered"] {
-  counter-reset: ds-list calc(var(--ds-list-start, 1) - 1);
-}`;
 injectStyles(listCss, "list");
 
 export class DsList extends HTMLElement {

--- a/packages/framework/src/elements/media/counter.css
+++ b/packages/framework/src/elements/media/counter.css
@@ -1,0 +1,1 @@
+ds-counter { display: inline; }

--- a/packages/framework/src/elements/media/counter.ts
+++ b/packages/framework/src/elements/media/counter.ts
@@ -5,7 +5,8 @@ import {
 } from "../../store/context/slideshow.js";
 import { injectStyles } from "../../utils/styles.js";
 
-const counterCss = `ds-counter { display: inline; }`;
+import counterCss from "./counter.css?raw";
+
 injectStyles(counterCss, "counter");
 
 export class DsCounter extends HTMLElement {

--- a/packages/framework/src/elements/media/image.css
+++ b/packages/framework/src/elements/media/image.css
@@ -1,0 +1,6 @@
+ds-image { display: contents; }
+ds-image img {
+  width: 100%;
+  display: block;
+  height: 100%;
+}

--- a/packages/framework/src/elements/media/image.ts
+++ b/packages/framework/src/elements/media/image.ts
@@ -1,12 +1,8 @@
 import { injectStyles } from "../../utils/styles.js";
 import { registerResource } from "../../utils/resource.js";
 
-const imageCss = `ds-image { display: contents; }
-ds-image img {
-  width: 100%;
-  display: block;
-  height: 100%;
-}`;
+import imageCss from "./image.css?raw";
+
 injectStyles(imageCss, "image");
 
 export class DsImage extends HTMLElement {

--- a/packages/framework/src/elements/media/reference.css
+++ b/packages/framework/src/elements/media/reference.css
@@ -1,0 +1,1 @@
+ds-reference { display: inline; }

--- a/packages/framework/src/elements/media/reference.ts
+++ b/packages/framework/src/elements/media/reference.ts
@@ -4,7 +4,8 @@ import {
 } from "../../store/context/slideshow.js";
 import { injectStyles } from "../../utils/styles.js";
 
-const referenceCss = `ds-reference { display: inline; }`;
+import referenceCss from "./reference.css?raw";
+
 injectStyles(referenceCss, "reference");
 
 export class DsReference extends HTMLElement {

--- a/packages/framework/src/elements/media/video.css
+++ b/packages/framework/src/elements/media/video.css
@@ -1,0 +1,11 @@
+ds-video {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+}
+
+ds-video video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}

--- a/packages/framework/src/elements/media/video.ts
+++ b/packages/framework/src/elements/media/video.ts
@@ -1,16 +1,7 @@
 import { injectStyles } from "../../utils/styles.js";
 
-const videoCss = `ds-video {
-  display: inline-block;
-  width: 100%;
-  height: 100%;
-}
+import videoCss from "./video.css?raw";
 
-ds-video video {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}`;
 injectStyles(videoCss, "video");
 
 export class DsVideo extends HTMLElement {

--- a/packages/framework/src/elements/overlay/loader.css
+++ b/packages/framework/src/elements/overlay/loader.css
@@ -1,0 +1,51 @@
+ds-loader {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0;
+  background-color: var(--ds-loader-bg, black);
+  color: var(--ds-loader-fg, white);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+}
+
+ds-loader[state=loading] {
+  opacity: 100%;
+}
+
+ds-loader[state=finished] {
+  display: none;
+}
+
+ds-loader .progress-track {
+  width: 80%;
+  height: 0.5rem;
+  background-color: var(--ds-loader-track, rgb(255 255 255 / 0.2));
+  border-radius: var(--ds-radius, 9999px);
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+}
+
+ds-loader .bar-inner {
+  height: 100%;
+  background-color: var(--ds-loader-bar, white);
+  border-radius: var(--ds-radius, 9999px);
+  transition: width 0.2s;
+}
+
+@keyframes pulse {
+  0% { opacity: 70%; }
+  50% { opacity: 100%; }
+  100% { opacity: 70%; }
+}
+
+.logo-text {
+  font-size: 3em;
+  font-weight: 900;
+  animation: pulse 2s ease-in-out infinite;
+}

--- a/packages/framework/src/elements/overlay/loader.css
+++ b/packages/framework/src/elements/overlay/loader.css
@@ -45,6 +45,7 @@ ds-loader .bar-inner {
 }
 
 .logo-text {
+  font-family: var(--ds-font-ui, system-ui, sans-serif);
   font-size: 3em;
   font-weight: 900;
   animation: pulse 2s ease-in-out infinite;

--- a/packages/framework/src/elements/overlay/loader.ts
+++ b/packages/framework/src/elements/overlay/loader.ts
@@ -3,57 +3,7 @@ import { RESOURCE_READY } from "../../utils/events.js";
 import type { ResourceRegistrationResult } from "../../utils/resource.js";
 import { injectStyles } from "../../utils/styles.js";
 
-const loaderCss = `ds-loader {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  inset: 0;
-  background-color: var(--ds-loader-bg, black);
-  color: var(--ds-loader-fg, white);
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  align-items: center;
-  justify-content: center;
-}
-
-ds-loader[state=loading] {
-  opacity: 100%;
-}
-
-ds-loader[state=finished] {
-  display: none;
-}
-
-ds-loader .progress-track {
-  width: 80%;
-  height: 0.5rem;
-  background-color: var(--ds-loader-track, rgb(255 255 255 / 0.2));
-  border-radius: var(--ds-radius, 9999px);
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-}
-
-ds-loader .bar-inner {
-  height: 100%;
-  background-color: var(--ds-loader-bar, white);
-  border-radius: var(--ds-radius, 9999px);
-  transition: width 0.2s;
-}
-
-@keyframes pulse {
-  0% { opacity: 70%; }
-  50% { opacity: 100%; }
-  100% { opacity: 70%; }
-}
-
-.logo-text {
-  font-size: 3em;
-  font-weight: 900;
-  animation: pulse 2s ease-in-out infinite;
-}`;
+import loaderCss from "./loader.css?raw";
 
 injectStyles(loaderCss, "loader");
 

--- a/packages/framework/src/elements/slideshow.css
+++ b/packages/framework/src/elements/slideshow.css
@@ -13,7 +13,7 @@ ds-slideshow {
   justify-content: center;
   align-items: center;
 
-  font-family: var(--ds-font-family, system-ui, sans-serif);
+  font-family: var(--ds-font-content, system-ui, sans-serif);
   font-size: var(--ds-font-size-base, 1rem);
 }
 

--- a/packages/framework/src/elements/slideshow.css
+++ b/packages/framework/src/elements/slideshow.css
@@ -1,0 +1,24 @@
+ds-slideshow {
+  --fit-scale: 1;
+
+  position: relative;
+  contain: layout style paint;
+
+  scale: var(--fit-scale);
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+
+  font-family: var(--ds-font-family, system-ui, sans-serif);
+  font-size: var(--ds-font-size-base, 1rem);
+}
+
+@layer dotslide {
+  ds-slideshow.loading {
+    opacity: 20%;
+  }
+}

--- a/packages/framework/src/elements/slideshow.ts
+++ b/packages/framework/src/elements/slideshow.ts
@@ -10,30 +10,7 @@ import {
 import type { ResourceRegistrationDetail } from "../utils/resource";
 import { injectStyles } from "../utils/styles";
 
-const slideshowCss = `ds-slideshow {
-  --fit-scale: 1;
-
-  position: relative;
-  contain: layout style paint;
-
-  scale: var(--fit-scale);
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-
-  font-family: var(--ds-font-family, system-ui, sans-serif);
-  font-size: var(--ds-font-size-base, 1rem);
-}
-
-@layer dotslide {
-  ds-slideshow.loading {
-    opacity: 20%;
-  }
-}`;
+import slideshowCss from "./slideshow.css?raw";
 
 injectStyles(slideshowCss, "slideshow");
 

--- a/packages/framework/src/styles/slideshow.css
+++ b/packages/framework/src/styles/slideshow.css
@@ -16,7 +16,7 @@ ds-slideshow {
   justify-content: center;
   align-items: center;
 
-  font-family: var(--ds-font-family, system-ui, sans-serif);
+  font-family: var(--ds-font-content, system-ui, sans-serif);
   font-size: var(--ds-font-size-base, 1rem);
 }
 

--- a/packages/framework/src/utils/styles.ts
+++ b/packages/framework/src/utils/styles.ts
@@ -7,7 +7,7 @@ const injectedStyles = new Set<string>();
 
 /**
  * Inject CSS into the document head.
- * Uses @layer dotslide for specificity control.
+ * Uses `@layer dotslide` for specificity control.
  * Only injects once per unique CSS content.
  */
 export function injectStyles(css: string, id?: string): void {

--- a/packages/framework/src/vite-env.d.ts
+++ b/packages/framework/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css?raw' {
+  const css: string;
+  export default css;
+}

--- a/packages/framework/themes/dark.css
+++ b/packages/framework/themes/dark.css
@@ -4,7 +4,8 @@
 :root {
   --ds-body-bg: #020617;
   --ds-slide-bg: #0f172a;
-  --ds-font-family: system-ui, sans-serif;
+  --ds-font-content: system-ui, sans-serif;
+  --ds-font-ui: system-ui, sans-serif;
   --ds-font-size-base: 1rem;
   --ds-accent: #818cf8;
   --ds-loader-bg: #020617;

--- a/packages/framework/themes/default.css
+++ b/packages/framework/themes/default.css
@@ -2,14 +2,18 @@
 /* Default (light) theme for @dotslide/framework.
    Import this file once in your presentation's root layout:
      import "@dotslide/framework/themes/default.css";
-   Then override any token to customise: */
+   Then override any token to customise:
+
+   --ds-font-content: slide content font.
+   --ds-font-ui: framework UI chrome font (controls, loader, progress). */
 
 @layer dotslide;
 
 :root {
   --ds-body-bg: black;
   --ds-slide-bg: white;
-  --ds-font-family: system-ui, sans-serif;
+  --ds-font-content: system-ui, sans-serif;
+  --ds-font-ui: system-ui, sans-serif;
   --ds-font-size-base: 1rem;
   --ds-accent: #6366f1;
   --ds-loader-bg: black;

--- a/packages/framework/tsdown.config.ts
+++ b/packages/framework/tsdown.config.ts
@@ -1,4 +1,34 @@
-import { defineConfig } from "tsdown";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, type TsdownPlugin } from "tsdown";
+
+const rawSuffix = "?raw";
+
+/**
+ * Resolves `?raw` imports (e.g. `./button.css?raw`) to the raw file text.
+ * Rolldown's built-in moduleTypes key by extension, so `.css?raw` won't
+ * match `.css` — a small plugin is the reliable route.
+ */
+const rawImportPlugin: TsdownPlugin = {
+  name: "dotslide:raw-import",
+  resolveId(source, importer) {
+    if (!source.endsWith(rawSuffix) || !importer) return null;
+    const file = source.slice(0, -rawSuffix.length);
+    const resolved = importer.startsWith("file://")
+      ? fileURLToPath(new URL(file, importer))
+      : resolve(dirname(importer), file);
+    return `${resolved}${rawSuffix}`;
+  },
+  load(id) {
+    if (!id.endsWith(rawSuffix)) return null;
+    const css = readFileSync(id.slice(0, -rawSuffix.length), "utf8");
+    return {
+      code: `export default ${JSON.stringify(css)};`,
+      moduleSideEffects: false,
+    };
+  },
+};
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -7,6 +37,7 @@ export default defineConfig({
   dts: true,
   minify: true,
   clean: true,
+  plugins: [rawImportPlugin],
   // Bundle these dependencies (don't externalize)
   deps: {
     neverBundle: ["zod"],

--- a/packages/framework/tsdown.config.ts
+++ b/packages/framework/tsdown.config.ts
@@ -18,6 +18,8 @@ const rawImportPlugin: TsdownPlugin = {
     const resolved = importer.startsWith("file://")
       ? fileURLToPath(new URL(file, importer))
       : resolve(dirname(importer), file);
+    // tell Rolldown to watch the file so changes trigger rebuild
+    this.addWatchFile(resolved);
     return `${resolved}${rawSuffix}`;
   },
   load(id) {


### PR DESCRIPTION
This PR improves the slide controls UI by making it hide when the mouse is inactive and putting it in a pill together with a slide counter. UI components now have their CSS in separate `.css` files, so it's easier to iterate on styling.

The UI font is now also controlled by `--ds-font-ui` (defaulting to the system UI font or a sans serif font) instead of by whatever the page sets.