### PR TITLE
feat(framework): add slide templating

### DIFF
--- a/.changeset/cozy-seas-try.md
+++ b/.changeset/cozy-seas-try.md
@@ -1,0 +1,5 @@
+---
+"@dotslide/framework": minor
+---
+
+Add slide templating features

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Focus on content, not configuration.
 - `<ds-image>` — Image with loading state.
 - `<ds-video>` — Video with slide-aware playback.
 - `<ds-overlay>` — Positioning container.
+- `<ds-slide-template>` — Reusable slide layout with named slots.
+- `<ds-slot>` — Content placeholder inside templates.
 
 ```html
 <!DOCTYPE html>
@@ -74,6 +76,21 @@ Focus on content, not configuration.
 ```html
 <ds-progress data-display="bar"></ds-progress>
 <p>Slide <ds-current-slide></ds-current-slide> of <ds-total-slides></ds-total-slides></p>
+```
+
+### 🧱 Slide templates
+
+Define reusable layouts once, apply them to any slide.
+
+```html
+<ds-slide-template name="title-content">
+  <h2><ds-slot name="title"></ds-slot></h2>
+  <div><ds-slot /></div>
+</ds-slide-template>
+
+<ds-slide template="title-content" ds-slot-title="Welcome">
+  <p>This is the body content.</p>
+</ds-slide>
 ```
 
 ## 🚀 Usage

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -69,9 +69,11 @@ npm install @dotslide/framework
 | Element | Description | Key Attributes |
 |---------|-------------|----------------|
 | `<ds-slideshow>` | Root container for the presentation | `data-slideshow-width`, `data-slideshow-height` |
-| `<ds-slide>` | Individual slide | — |
+| `<ds-slide>` | Individual slide | `template` |
 | `<ds-step>` | Progressive disclosure within a slide | `data-from`, `data-to` |
 | `<ds-section>` | Groups slides into sections | `level`, `title` |
+| `<ds-slide-template>` | Reusable slide layout with named slots | `name` |
+| `<ds-slot>` | Content placeholder inside a template | `name` |
 
 ### Controls
 
@@ -171,6 +173,34 @@ Create custom counters and refer to them deterministically from other slides.
 <ds-slide>
   <p>See Figure <ds-counter data-type="figure" data-id="fig1"></ds-counter></p>
   <p>Later: As shown in Figure <ds-reference data-id="fig1"></ds-reference>...</p>
+</ds-slide>
+```
+
+### Slide Templates
+
+Define reusable layouts with `<ds-slide-template>` and `<ds-slot>`, then apply them to slides with the `template` attribute.
+
+Templates must appear before the slides that reference them in DOM order.
+
+```html
+<ds-slide-template name="main">
+  <div class="slide-header">
+    <h2><ds-slot name="title"></ds-slot></h2>
+  </div>
+  <div class="slide-body">
+    <ds-slot />
+  </div>
+</ds-slide-template>
+
+<!-- Text shorthand via ds-slot-* attributes -->
+<ds-slide template="main" ds-slot-title="Welcome">
+  <p>Body content goes into the unnamed slot.</p>
+</ds-slide>
+
+<!-- Rich content via slot attribute on children -->
+<ds-slide template="main">
+  <span slot="title">Custom <em>rich</em> title</span>
+  <p>Body content goes into the unnamed slot.</p>
 </ds-slide>
 ```
 

--- a/packages/framework/src/elements/index.ts
+++ b/packages/framework/src/elements/index.ts
@@ -19,6 +19,7 @@ export { DsVideo } from "./media/video.js";
 export { Loader } from "./overlay/loader.js";
 export { Section } from "./section.js";
 export { Slide } from "./slide.js";
+export { SlideTemplate } from "./slide-template.js";
 export { Slideshow } from "./slideshow.js";
 export { Step } from "./step.js";
 export { CurrentSection } from "./widgets/current-section.js";

--- a/packages/framework/src/elements/slide-template.ts
+++ b/packages/framework/src/elements/slide-template.ts
@@ -8,10 +8,6 @@ const css = `@layer dotslide {
   ds-slide-template {
     display: none;
   }
-
-  ds-slot {
-    display: contents;
-  }
 }`;
 
 injectStyles(css, "slide-template");
@@ -28,71 +24,70 @@ injectStyles(css, "slide-template");
  *
  * @returns `true` if the template was found and applied.
  */
-export async function applyTemplate(host: HTMLElement, name: string): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-  withSlideshowContext(host, (ctx) => {
-    const template = ctx.get().templates[name];
-    if (!template) {
-      console.warn(`Template ${name} not found`)
-      reject(`Tempalte ${name} not found. Possible values: [${Object.keys(ctx.get().templates).join(', ')}]`)
-      return;
-    };
+export function applyTemplate(
+  host: HTMLElement,
+  name: string,
+  ctx: SlideshowStore,
+): boolean {
+  const template = ctx.get().templates[name];
+  if (!template) {
+    return false;
+  }
 
-    const fragment = template.content.cloneNode(true) as DocumentFragment;
+  const fragment = template.content.cloneNode(true) as DocumentFragment;
 
-    // Collect text content from ds-slot-* attributes (text shorthand)
-    const attrSlots = new Map<string, Text>();
-    for (const attr of host.attributes) {
-      if (attr.name.startsWith("ds-slot-")) {
-        const slotName = attr.name.slice("ds-slot-".length);
-        if (slotName)
-          attrSlots.set(slotName, document.createTextNode(attr.value));
+  // Collect text content from ds-slot-* attributes (text shorthand)
+  const attrSlots = new Map<string, Text>();
+  for (const attr of host.attributes) {
+    if (attr.name.startsWith("ds-slot-")) {
+      const slotName = attr.name.slice("ds-slot-".length);
+      if (slotName)
+        attrSlots.set(slotName, document.createTextNode(attr.value));
+    }
+  }
+
+  // Partition host children by slot name (child elements take precedence)
+  const namedSlots = new Map<string, Node[]>();
+  const unnamed: Node[] = [];
+  for (const child of Array.from(host.childNodes)) {
+    const slotName =
+      child instanceof Element ? child.getAttribute("slot") : null;
+    if (slotName) {
+      let bucket = namedSlots.get(slotName);
+      if (!bucket) {
+        bucket = [];
+        namedSlots.set(slotName, bucket);
+      }
+      bucket.push(child);
+    } else {
+      unnamed.push(child);
+    }
+  }
+
+  // Replace each <ds-slot> marker with its distributed children
+  for (const slot of fragment.querySelectorAll("ds-slot")) {
+    const slotName = slot.getAttribute("name") ?? "";
+    // Child elements win; attribute text fills in when no child claimed the slot
+    const childNodes = slotName ? (namedSlots.get(slotName) ?? []) : unnamed;
+    const attrText = slotName ? attrSlots.get(slotName) : undefined;
+    const nodes =
+      childNodes.length > 0 ? childNodes : attrText ? [attrText] : [];
+    if (nodes.length > 0) {
+      for (const node of nodes) slot.parentNode?.insertBefore(node, slot);
+    } else {
+      // Fallback: keep the slot's own children (native <slot> behavior)
+      while (slot.firstChild) {
+        slot.parentNode?.insertBefore(slot.firstChild, slot);
       }
     }
+    slot.remove();
+  }
 
-    // Partition host children by slot name (child elements take precedence)
-    const namedSlots = new Map<string, Node[]>();
-    const unnamed: Node[] = [];
-    for (const child of Array.from(host.childNodes)) {
-      const slotName =
-        child instanceof Element ? child.getAttribute("slot") : null;
-      if (slotName) {
-        let bucket = namedSlots.get(slotName);
-        if (!bucket) {
-          bucket = [];
-          namedSlots.set(slotName, bucket);
-        }
-        bucket.push(child);
-      } else {
-        unnamed.push(child);
-      }
-    }
+  // Clear the host's remaining children (their nodes were moved above).
+  while (host.firstChild) host.removeChild(host.firstChild);
+  host.appendChild(fragment);
 
-    // Replace each <ds-slot> marker with its distributed children
-    for (const slot of fragment.querySelectorAll("ds-slot")) {
-      const slotName = slot.getAttribute("name") ?? "";
-      // Child elements win; attribute text fills in when no child claimed the slot
-      const childNodes = slotName ? (namedSlots.get(slotName) ?? []) : unnamed;
-      const attrText = slotName ? attrSlots.get(slotName) : undefined;
-      const nodes =
-        childNodes.length > 0 ? childNodes : attrText ? [attrText] : [];
-      if (nodes.length > 0) {
-        for (const node of nodes) slot.parentNode?.insertBefore(node, slot);
-      } else {
-        // Fallback: keep the slot's own children (native <slot> behavior)
-        while (slot.firstChild) {
-          slot.parentNode?.insertBefore(slot.firstChild, slot);
-        }
-      }
-      slot.remove();
-    }
-
-    host.appendChild(fragment);
-    console.log("Template application successful.")
-
-    resolve(true);
-  });
-  })
+  return true;
 }
 
 /**

--- a/packages/framework/src/elements/slide-template.ts
+++ b/packages/framework/src/elements/slide-template.ts
@@ -1,0 +1,107 @@
+import { injectStyles } from "../utils/styles";
+
+const css = `@layer dotslide {
+  ds-slide-template {
+    display: none;
+  }
+
+  ds-slot {
+    display: contents;
+  }
+}`;
+
+injectStyles(css, "slide-template");
+
+/** Registry of named slide templates keyed by their `name` attribute. */
+const templates = new Map<string, HTMLTemplateElement>();
+
+/**
+ * Apply a named template to a host element. Clones the template's content
+ * and distributes the host's children into `<ds-slot>` markers by matching
+ * `slot="name"` attributes — mirroring native Shadow DOM slot distribution
+ * (including fallback content) without requiring a shadow root.
+ *
+ * Slot content can come from two sources (child elements take precedence):
+ * - `slot="name"` attribute on child elements (rich content)
+ * - `ds-slot-name="text"` attribute on the host (text shorthand)
+ *
+ * @returns `true` if the template was found and applied.
+ */
+export function applyTemplate(host: HTMLElement, name: string): boolean {
+  const template = templates.get(name);
+  if (!template) return false;
+
+  const fragment = template.content.cloneNode(true) as DocumentFragment;
+
+  // Collect text content from ds-slot-* attributes (text shorthand)
+  const attrSlots = new Map<string, Text>();
+  for (const attr of host.attributes) {
+    if (attr.name.startsWith("ds-slot-")) {
+      const slotName = attr.name.slice("ds-slot-".length);
+      if (slotName)
+        attrSlots.set(slotName, document.createTextNode(attr.value));
+    }
+  }
+
+  // Partition host children by slot name (child elements take precedence)
+  const namedSlots = new Map<string, Node[]>();
+  const unnamed: Node[] = [];
+  for (const child of Array.from(host.childNodes)) {
+    const slotName =
+      child instanceof Element ? child.getAttribute("slot") : null;
+    if (slotName) {
+      let bucket = namedSlots.get(slotName);
+      if (!bucket) {
+        bucket = [];
+        namedSlots.set(slotName, bucket);
+      }
+      bucket.push(child);
+    } else {
+      unnamed.push(child);
+    }
+  }
+
+  // Replace each <ds-slot> marker with its distributed children
+  for (const slot of fragment.querySelectorAll("ds-slot")) {
+    const slotName = slot.getAttribute("name") ?? "";
+    // Child elements win; attribute text fills in when no child claimed the slot
+    const childNodes = slotName ? (namedSlots.get(slotName) ?? []) : unnamed;
+    const attrText = slotName ? attrSlots.get(slotName) : undefined;
+    const nodes =
+      childNodes.length > 0 ? childNodes : attrText ? [attrText] : [];
+    if (nodes.length > 0) {
+      for (const node of nodes) slot.parentNode?.insertBefore(node, slot);
+    } else {
+      // Fallback: keep the slot's own children (native <slot> behavior)
+      while (slot.firstChild) {
+        slot.parentNode?.insertBefore(slot.firstChild, slot);
+      }
+    }
+    slot.remove();
+  }
+
+  host.appendChild(fragment);
+  return true;
+}
+
+/**
+ * Custom element `<ds-slide-template>` that registers a named slide template.
+ *
+ * Define templates with `<ds-slot>` markers; apply them with
+ * `<ds-slide template="name">`. The template's children are moved into an
+ * inert `<template>` element for efficient cloning.
+ *
+ * Templates must appear before the slides that reference them in DOM order
+ * so they register before the slide's `connectedCallback` runs.
+ */
+export class SlideTemplate extends HTMLElement {
+  connectedCallback(): void {
+    const name = this.getAttribute("name");
+    if (!name) return;
+    const template = document.createElement("template");
+    while (this.firstChild) template.content.appendChild(this.firstChild);
+    templates.set(name, template);
+  }
+}
+
+customElements.define("ds-slide-template", SlideTemplate);

--- a/packages/framework/src/elements/slide-template.ts
+++ b/packages/framework/src/elements/slide-template.ts
@@ -1,3 +1,7 @@
+import {
+  type SlideshowStore,
+  withSlideshowContext,
+} from "../store/context/slideshow";
 import { injectStyles } from "../utils/styles";
 
 const css = `@layer dotslide {
@@ -12,9 +16,6 @@ const css = `@layer dotslide {
 
 injectStyles(css, "slide-template");
 
-/** Registry of named slide templates keyed by their `name` attribute. */
-const templates = new Map<string, HTMLTemplateElement>();
-
 /**
  * Apply a named template to a host element. Clones the template's content
  * and distributes the host's children into `<ds-slot>` markers by matching
@@ -27,61 +28,71 @@ const templates = new Map<string, HTMLTemplateElement>();
  *
  * @returns `true` if the template was found and applied.
  */
-export function applyTemplate(host: HTMLElement, name: string): boolean {
-  const template = templates.get(name);
-  if (!template) return false;
+export async function applyTemplate(host: HTMLElement, name: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+  withSlideshowContext(host, (ctx) => {
+    const template = ctx.get().templates[name];
+    if (!template) {
+      console.warn(`Template ${name} not found`)
+      reject(`Tempalte ${name} not found. Possible values: [${Object.keys(ctx.get().templates).join(', ')}]`)
+      return;
+    };
 
-  const fragment = template.content.cloneNode(true) as DocumentFragment;
+    const fragment = template.content.cloneNode(true) as DocumentFragment;
 
-  // Collect text content from ds-slot-* attributes (text shorthand)
-  const attrSlots = new Map<string, Text>();
-  for (const attr of host.attributes) {
-    if (attr.name.startsWith("ds-slot-")) {
-      const slotName = attr.name.slice("ds-slot-".length);
-      if (slotName)
-        attrSlots.set(slotName, document.createTextNode(attr.value));
-    }
-  }
-
-  // Partition host children by slot name (child elements take precedence)
-  const namedSlots = new Map<string, Node[]>();
-  const unnamed: Node[] = [];
-  for (const child of Array.from(host.childNodes)) {
-    const slotName =
-      child instanceof Element ? child.getAttribute("slot") : null;
-    if (slotName) {
-      let bucket = namedSlots.get(slotName);
-      if (!bucket) {
-        bucket = [];
-        namedSlots.set(slotName, bucket);
-      }
-      bucket.push(child);
-    } else {
-      unnamed.push(child);
-    }
-  }
-
-  // Replace each <ds-slot> marker with its distributed children
-  for (const slot of fragment.querySelectorAll("ds-slot")) {
-    const slotName = slot.getAttribute("name") ?? "";
-    // Child elements win; attribute text fills in when no child claimed the slot
-    const childNodes = slotName ? (namedSlots.get(slotName) ?? []) : unnamed;
-    const attrText = slotName ? attrSlots.get(slotName) : undefined;
-    const nodes =
-      childNodes.length > 0 ? childNodes : attrText ? [attrText] : [];
-    if (nodes.length > 0) {
-      for (const node of nodes) slot.parentNode?.insertBefore(node, slot);
-    } else {
-      // Fallback: keep the slot's own children (native <slot> behavior)
-      while (slot.firstChild) {
-        slot.parentNode?.insertBefore(slot.firstChild, slot);
+    // Collect text content from ds-slot-* attributes (text shorthand)
+    const attrSlots = new Map<string, Text>();
+    for (const attr of host.attributes) {
+      if (attr.name.startsWith("ds-slot-")) {
+        const slotName = attr.name.slice("ds-slot-".length);
+        if (slotName)
+          attrSlots.set(slotName, document.createTextNode(attr.value));
       }
     }
-    slot.remove();
-  }
 
-  host.appendChild(fragment);
-  return true;
+    // Partition host children by slot name (child elements take precedence)
+    const namedSlots = new Map<string, Node[]>();
+    const unnamed: Node[] = [];
+    for (const child of Array.from(host.childNodes)) {
+      const slotName =
+        child instanceof Element ? child.getAttribute("slot") : null;
+      if (slotName) {
+        let bucket = namedSlots.get(slotName);
+        if (!bucket) {
+          bucket = [];
+          namedSlots.set(slotName, bucket);
+        }
+        bucket.push(child);
+      } else {
+        unnamed.push(child);
+      }
+    }
+
+    // Replace each <ds-slot> marker with its distributed children
+    for (const slot of fragment.querySelectorAll("ds-slot")) {
+      const slotName = slot.getAttribute("name") ?? "";
+      // Child elements win; attribute text fills in when no child claimed the slot
+      const childNodes = slotName ? (namedSlots.get(slotName) ?? []) : unnamed;
+      const attrText = slotName ? attrSlots.get(slotName) : undefined;
+      const nodes =
+        childNodes.length > 0 ? childNodes : attrText ? [attrText] : [];
+      if (nodes.length > 0) {
+        for (const node of nodes) slot.parentNode?.insertBefore(node, slot);
+      } else {
+        // Fallback: keep the slot's own children (native <slot> behavior)
+        while (slot.firstChild) {
+          slot.parentNode?.insertBefore(slot.firstChild, slot);
+        }
+      }
+      slot.remove();
+    }
+
+    host.appendChild(fragment);
+    console.log("Template application successful.")
+
+    resolve(true);
+  });
+  })
 }
 
 /**
@@ -96,11 +107,17 @@ export function applyTemplate(host: HTMLElement, name: string): boolean {
  */
 export class SlideTemplate extends HTMLElement {
   connectedCallback(): void {
-    const name = this.getAttribute("name");
+    withSlideshowContext(this, (ctx) => {
+      this._registerTemplate(ctx, this.getAttribute("name"));
+    });
+  }
+
+  private _registerTemplate(ctx: SlideshowStore, name: string | null): void {
     if (!name) return;
     const template = document.createElement("template");
     while (this.firstChild) template.content.appendChild(this.firstChild);
-    templates.set(name, template);
+    const current = ctx.get().templates;
+    ctx.setKey("templates", { ...current, [name]: template });
   }
 }
 

--- a/packages/framework/src/elements/slide.ts
+++ b/packages/framework/src/elements/slide.ts
@@ -27,7 +27,7 @@ const css = `@layer dotslide {
 injectStyles(css, "slide");
 
 export class Slide extends HTMLElement {
-  connectedCallback() {
+  async connectedCallback() {
     const slideshow = this.closest("ds-slideshow");
     if (!slideshow) {
       console.warn("[dotslide]", "Slide is not rendered inside a ds-slideshow");
@@ -37,7 +37,7 @@ export class Slide extends HTMLElement {
     // Apply template before index calculation so template-introduced
     // ds-step elements are visible when the slideshow builds navigation
     const templateName = this.getAttribute("template");
-    if (templateName && !applyTemplate(this, templateName)) {
+    if (templateName && (await applyTemplate(this, templateName) !== true)) {
       console.warn(
         "[dotslide]",
         `Slide template "${templateName}" not found — define <ds-slide-template name="${templateName}"> before this slide`,

--- a/packages/framework/src/elements/slide.ts
+++ b/packages/framework/src/elements/slide.ts
@@ -1,5 +1,6 @@
 import { createSlideContext } from "../store/context/slide";
 import { injectStyles } from "../utils/styles";
+import { applyTemplate } from "./slide-template";
 
 const css = `@layer dotslide {
   ds-slide {
@@ -33,13 +34,26 @@ export class Slide extends HTMLElement {
       return;
     }
 
+    // Apply template before index calculation so template-introduced
+    // ds-step elements are visible when the slideshow builds navigation
+    const templateName = this.getAttribute("template");
+    if (templateName && !applyTemplate(this, templateName)) {
+      console.warn(
+        "[dotslide]",
+        `Slide template "${templateName}" not found — define <ds-slide-template name="${templateName}"> before this slide`,
+      );
+    }
+
     const slides = Array.from(
       slideshow.querySelectorAll<HTMLElement>("ds-slide"),
     );
     const slideIndex = slides.indexOf(this);
 
     if (slideIndex === -1) {
-      console.warn("[dotslide]", "Slide could not determine its index within the slideshow");
+      console.warn(
+        "[dotslide]",
+        "Slide could not determine its index within the slideshow",
+      );
       return;
     }
 

--- a/packages/framework/src/elements/slide.ts
+++ b/packages/framework/src/elements/slide.ts
@@ -1,4 +1,5 @@
 import { createSlideContext } from "../store/context/slide";
+import { withSlideshowContext } from "../store/context/slideshow";
 import { injectStyles } from "../utils/styles";
 import { applyTemplate } from "./slide-template";
 
@@ -27,38 +28,40 @@ const css = `@layer dotslide {
 injectStyles(css, "slide");
 
 export class Slide extends HTMLElement {
-  async connectedCallback() {
+  connectedCallback() {
     const slideshow = this.closest("ds-slideshow");
     if (!slideshow) {
       console.warn("[dotslide]", "Slide is not rendered inside a ds-slideshow");
       return;
     }
 
-    // Apply template before index calculation so template-introduced
-    // ds-step elements are visible when the slideshow builds navigation
-    const templateName = this.getAttribute("template");
-    if (templateName && (await applyTemplate(this, templateName) !== true)) {
-      console.warn(
-        "[dotslide]",
-        `Slide template "${templateName}" not found — define <ds-slide-template name="${templateName}"> before this slide`,
+    withSlideshowContext(this, (ctx) => {
+      // Apply template before index calculation so template-introduced
+      // ds-step elements are visible when the slideshow builds navigation
+      const templateName = this.getAttribute("template");
+      if (templateName && !applyTemplate(this, templateName, ctx)) {
+        console.warn(
+          "[dotslide]",
+          `Slide template "${templateName}" not found — define <ds-slide-template name="${templateName}"> before this slide`,
+        );
+      }
+
+      const slides = Array.from(
+        slideshow.querySelectorAll<HTMLElement>("ds-slide"),
       );
-    }
+      const slideIndex = slides.indexOf(this);
 
-    const slides = Array.from(
-      slideshow.querySelectorAll<HTMLElement>("ds-slide"),
-    );
-    const slideIndex = slides.indexOf(this);
+      if (slideIndex === -1) {
+        console.warn(
+          "[dotslide]",
+          "Slide could not determine its index within the slideshow",
+        );
+        return;
+      }
 
-    if (slideIndex === -1) {
-      console.warn(
-        "[dotslide]",
-        "Slide could not determine its index within the slideshow",
-      );
-      return;
-    }
-
-    this.setAttribute("data-slide-index", slideIndex.toString());
-    createSlideContext(this, { index: slideIndex });
+      this.setAttribute("data-slide-index", slideIndex.toString());
+      createSlideContext(this, { index: slideIndex });
+    });
   }
 }
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -17,6 +17,7 @@ import { DsVideo } from "./elements/media/video";
 import { Loader } from "./elements/overlay/loader";
 import { Section } from "./elements/section";
 import { Slide } from "./elements/slide";
+import { SlideTemplate } from "./elements/slide-template";
 import { Slideshow } from "./elements/slideshow";
 import { Step } from "./elements/step";
 import { CurrentSection } from "./elements/widgets/current-section";
@@ -90,6 +91,7 @@ export {
   Slide,
   SlideControls,
   Slideshow,
+  SlideTemplate,
   Step,
   TotalSlides,
 };
@@ -99,6 +101,7 @@ declare global {
   interface HTMLElementTagNameMap {
     "ds-slideshow": Slideshow;
     "ds-slide": Slide;
+    "ds-slide-template": SlideTemplate;
     "ds-step": Step;
     "ds-section": Section;
     "ds-keyboard-handler": KeyboardHandler;

--- a/packages/framework/src/store/context/slideshow.ts
+++ b/packages/framework/src/store/context/slideshow.ts
@@ -81,8 +81,7 @@ type DerivedFields =
   | "phase"
   | "pending"
   | "ready"
-  | "counters"
-  | "templates";
+  | "counters";
 
 export const createSlideshowContext = (
   root: HTMLElement,

--- a/packages/framework/src/store/context/slideshow.ts
+++ b/packages/framework/src/store/context/slideshow.ts
@@ -42,6 +42,9 @@ export type SlideshowContext = {
   /** Map of counter types to their instances. Each instance gets a sequential value. */
   counters: Record<string, CounterInfo[]>;
 
+  /** Registry of named slide templates keyed by their `name` attribute. */
+  templates: Record<string, HTMLTemplateElement>;
+
   // — Derived fields (auto-updated when navigationIndex changes) —
 
   /** Index of the currently visible slide */
@@ -78,7 +81,8 @@ type DerivedFields =
   | "phase"
   | "pending"
   | "ready"
-  | "counters";
+  | "counters"
+  | "templates";
 
 export const createSlideshowContext = (
   root: HTMLElement,
@@ -103,6 +107,8 @@ export const createSlideshowContext = (
     ready: false,
     // Counter state — starts empty, counters register themselves
     counters: {},
+    // Template registry — starts empty, templates register themselves
+    templates: {},
   });
 
   // Keep derived fields in sync when navigationIndex changes.


### PR DESCRIPTION
This PR implements template support for presentations, allowing creating predefined Slide designs with slots.

The new `<ds-slide-template name="template-name">` element needs to be placed within a `<ds-slideshow>` component, then a `ds-slide` component can reuse the template via a `template="template-name"` attribute, filling in named slots by placing a `slot="slot-name"` attribute on the slotted element.

Here's a concrete example showcasing all the features:  

```html
<ds-slideshow>
  <!-- Step 1: define template(s) -->
  <ds-slide-template name="content">
    <div class="p-8">
      <h2 class="uppercase font-bold text-xl">
        <!-- named slots -->
        <ds-slot name="title" />
      </h2>
      <div class="flex flex-col gap-2">
        <!-- non-named slots are the default -->
        <ds-slot />
      </div>
    </div>
  </ds-slide-template>

  <!-- Step 2: use them via the `template` attribute -->
  <ds-slide template="content">
    <!-- The span elements goes into the `title` slot --> 
    <span slot="title">Why is dotSlide so good?</span>

    <!-- Other elements automatically go to the default (unnamed) slot -->
    <ul>
      <li>Single-file presentations</li>
      <li>No need to re-engineer presentation mechanics</li>
      <li>Open-source</li>
      <li>...</li>
    </ul>
  </ds-slide>

  <!-- Or use shorthands for small slots like titles: -->
  <ds-slide template="content" data-slot-title="Why is dotSlide so good? (cont.)">
    <!-- Content comes here -->
  </ds-slide>

</ds-slideshow>
```