### PR TITLE
refactor(framework): move remaining component CSS to separate files

### DIFF
--- a/packages/framework/src/elements/slide-template.css
+++ b/packages/framework/src/elements/slide-template.css
@@ -1,0 +1,3 @@
+ds-slide-template {
+  display: none;
+}

--- a/packages/framework/src/elements/slide-template.ts
+++ b/packages/framework/src/elements/slide-template.ts
@@ -3,14 +3,9 @@ import {
   withSlideshowContext,
 } from "../store/context/slideshow";
 import { injectStyles } from "../utils/styles";
+import slideTemplateCss from "./slide-template.css?raw";
 
-const css = `@layer dotslide {
-  ds-slide-template {
-    display: none;
-  }
-}`;
-
-injectStyles(css, "slide-template");
+injectStyles(slideTemplateCss, "slide-template");
 
 /**
  * Apply a named template to a host element. Clones the template's content

--- a/packages/framework/src/elements/slide.css
+++ b/packages/framework/src/elements/slide.css
@@ -1,0 +1,19 @@
+ds-slide {
+  position: relative;
+  background-color: var(--ds-slide-bg, white);
+  width: calc(var(--slide-width) * var(--slide-scale));
+  height: calc(var(--slide-height) * var(--slide-scale));
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+ds-slide:not(.active) {
+  display: none;
+}
+
+ds-slide > div.slide-container {
+  width: var(--slide-width);
+  height: var(--slide-height);
+  scale: var(--slide-scale);
+  transform-origin: 0 0;
+}

--- a/packages/framework/src/elements/slide.ts
+++ b/packages/framework/src/elements/slide.ts
@@ -1,31 +1,10 @@
 import { createSlideContext } from "../store/context/slide";
 import { withSlideshowContext } from "../store/context/slideshow";
 import { injectStyles } from "../utils/styles";
+import slideCss from "./slide.css?raw";
 import { applyTemplate } from "./slide-template";
 
-const css = `@layer dotslide {
-  ds-slide {
-    position: relative;
-    background-color: var(--ds-slide-bg, white);
-    width: calc(var(--slide-width) * var(--slide-scale));
-    height: calc(var(--slide-height) * var(--slide-scale));
-    flex-shrink: 0;
-    overflow: hidden;
-  }
-
-  ds-slide:not(.active) {
-    display: none;
-  }
-
-  ds-slide > div.slide-container {
-    width: var(--slide-width);
-    height: var(--slide-height);
-    scale: var(--slide-scale);
-    transform-origin: 0 0;
-  }
-}`;
-
-injectStyles(css, "slide");
+injectStyles(slideCss, "slide");
 
 export class Slide extends HTMLElement {
   connectedCallback() {

--- a/packages/framework/src/elements/step.css
+++ b/packages/framework/src/elements/step.css
@@ -1,0 +1,7 @@
+ds-step {
+  display: contents;
+}
+
+ds-step:not(.active) {
+  visibility: hidden;
+}

--- a/packages/framework/src/elements/step.ts
+++ b/packages/framework/src/elements/step.ts
@@ -1,32 +1,22 @@
-import { injectStyles } from "../utils/styles"
+import { injectStyles } from "../utils/styles";
+import stepCss from "./step.css?raw";
 
-const css = `@layer dotslide {
-  ds-step {
-    display: contents;
-  }
-
-  ds-step:not(.active) {
-    visibility: hidden;
-  }
-}`
-
-injectStyles(css, "step")
+injectStyles(stepCss, "step");
 
 export class Step extends HTMLElement {
-  connectedCallback() {
-  }
+  connectedCallback() {}
 
   /** First step where this content is visible (inclusive, 1-based) */
   get from(): number | undefined {
-    const val = this.dataset.from
-    return val ? parseInt(val, 10) : undefined
+    const val = this.dataset.from;
+    return val ? parseInt(val, 10) : undefined;
   }
 
   /** Last step where this content is visible (inclusive, 1-based) */
   get to(): number | undefined {
-    const val = this.dataset.to
-    return val ? parseInt(val, 10) : undefined
+    const val = this.dataset.to;
+    return val ? parseInt(val, 10) : undefined;
   }
 }
 
-customElements.define("ds-step", Step)
+customElements.define("ds-step", Step);

--- a/packages/framework/src/elements/widgets/current-section.css
+++ b/packages/framework/src/elements/widgets/current-section.css
@@ -1,0 +1,3 @@
+ds-current-section {
+  display: inline;
+}

--- a/packages/framework/src/elements/widgets/current-section.ts
+++ b/packages/framework/src/elements/widgets/current-section.ts
@@ -1,10 +1,9 @@
 import { useSlideContext } from "../../store/context/slide.js";
 import { createSectionContext } from "../../store/index.js";
 import { injectStyles } from "../../utils/styles.js";
+import currentSectionCss from "./current-section.css?raw";
 
-const css = "ds-current-section { display: inline; }";
-
-injectStyles(css, "current-section");
+injectStyles(currentSectionCss, "current-section");
 
 export class CurrentSection extends HTMLElement {
   private _unsubscribe?: () => void;

--- a/packages/framework/src/elements/widgets/current-slide.css
+++ b/packages/framework/src/elements/widgets/current-slide.css
@@ -1,0 +1,3 @@
+ds-current-slide {
+  display: inline;
+}

--- a/packages/framework/src/elements/widgets/current-slide.ts
+++ b/packages/framework/src/elements/widgets/current-slide.ts
@@ -1,11 +1,10 @@
-import { injectStyles } from "../../utils/styles.js";
-import { createSectionContext } from "../../store/index.js";
 import { useSlideContext } from "../../store/context/slide.js";
+import { createSectionContext } from "../../store/index.js";
 import { getSlidePositionInSection } from "../../utils/section.js";
+import { injectStyles } from "../../utils/styles.js";
+import currentSlideCss from "./current-slide.css?raw";
 
-const css = "ds-current-slide { display: inline; }";
-
-injectStyles(css, "current-slide");
+injectStyles(currentSlideCss, "current-slide");
 
 export class CurrentSlide extends HTMLElement {
   private _unsubscribe?: () => void;
@@ -31,7 +30,11 @@ export class CurrentSlide extends HTMLElement {
       this._unsubscribe = sectionStore.subscribe((ctx) => {
         if (!ctx.initialized) return;
         this._unsubscribe?.();
-        const pos = getSlidePositionInSection(slideshowRoot, slideIndex, within);
+        const pos = getSlidePositionInSection(
+          slideshowRoot,
+          slideIndex,
+          within,
+        );
         this.textContent = pos ? String(pos.position) : "?";
       });
     });

--- a/packages/framework/src/elements/widgets/progress.css
+++ b/packages/framework/src/elements/widgets/progress.css
@@ -1,0 +1,16 @@
+ds-progress {
+  display: inline;
+}
+ds-progress .track {
+  display: inline-block;
+  width: 100%;
+  height: 0.4em;
+  background: color-mix(in srgb, currentColor 20%, transparent);
+  border-radius: 9999px;
+}
+ds-progress .fill {
+  height: 100%;
+  background: currentColor;
+  border-radius: inherit;
+  transition: width 0.2s;
+}

--- a/packages/framework/src/elements/widgets/progress.ts
+++ b/packages/framework/src/elements/widgets/progress.ts
@@ -3,23 +3,9 @@ import { useSlideshowContext } from "../../store/context/slideshow.js";
 import { createSectionContext } from "../../store/index.js";
 import { getSlidePositionInSection } from "../../utils/section.js";
 import { injectStyles } from "../../utils/styles.js";
+import progressCss from "./progress.css?raw";
 
-const css = `ds-progress { display: inline; }
-ds-progress .track {
-  display: inline-block;
-  width: 100%;
-  height: 0.4em;
-  background: color-mix(in srgb, currentColor 20%, transparent);
-  border-radius: 9999px;
-}
-ds-progress .fill {
-  height: 100%;
-  background: currentColor;
-  border-radius: inherit;
-  transition: width 0.2s;
-}`;
-
-injectStyles(css, "progress");
+injectStyles(progressCss, "progress");
 
 export class Progress extends HTMLElement {
   private _unsubscribe?: () => void;
@@ -43,9 +29,11 @@ export class Progress extends HTMLElement {
 
       const slideCtx = useSlideContext(this);
       if (!slideCtx) {
-        console.warn("<ds-progress> was place outside of a <ds-slide>. This is not supported.")
+        console.warn(
+          "<ds-progress> was place outside of a <ds-slide>. This is not supported.",
+        );
         return;
-      };
+      }
       const slideIndex = slideCtx.get().index;
 
       const slideshowRoot = this.closest("ds-slideshow");

--- a/packages/framework/src/elements/widgets/total-slides.css
+++ b/packages/framework/src/elements/widgets/total-slides.css
@@ -1,0 +1,3 @@
+ds-total-slides {
+  display: inline;
+}

--- a/packages/framework/src/elements/widgets/total-slides.ts
+++ b/packages/framework/src/elements/widgets/total-slides.ts
@@ -1,12 +1,11 @@
-import { injectStyles } from "../../utils/styles.js";
-import { createSectionContext } from "../../store/index.js";
 import { useSlideContext } from "../../store/context/slide.js";
 import { useSlideshowContext } from "../../store/context/slideshow.js";
+import { createSectionContext } from "../../store/index.js";
 import { getSlidePositionInSection } from "../../utils/section.js";
+import { injectStyles } from "../../utils/styles.js";
+import totalSlidesCss from "./total-slides.css?raw";
 
-const css = "ds-total-slides { display: inline; }";
-
-injectStyles(css, "total-slides");
+injectStyles(totalSlidesCss, "total-slides");
 
 export class TotalSlides extends HTMLElement {
   private _unsubscribe?: () => void;
@@ -37,7 +36,11 @@ export class TotalSlides extends HTMLElement {
       this._unsubscribe = sectionStore.subscribe((ctx) => {
         if (!ctx.initialized) return;
         this._unsubscribe?.();
-        const pos = getSlidePositionInSection(slideshowRoot, slideIndex, within);
+        const pos = getSlidePositionInSection(
+          slideshowRoot,
+          slideIndex,
+          within,
+        );
         this.textContent = pos ? String(pos.total) : "?";
       });
     });


### PR DESCRIPTION
This PR moves the remaining CSS-in-JS styling to external files in the framework.