### PR TITLE
fix(framework): make scaling consistent

### DIFF
--- a/.changeset/vast-planes-hug.md
+++ b/.changeset/vast-planes-hug.md
@@ -1,0 +1,5 @@
+---
+"@dotslide/framework": patch
+---
+
+Fix scaling, use stacked grid for slide positioning

--- a/packages/framework/src/elements/slide.css
+++ b/packages/framework/src/elements/slide.css
@@ -1,19 +1,14 @@
 ds-slide {
   position: relative;
   background-color: var(--ds-slide-bg, white);
-  width: calc(var(--slide-width) * var(--slide-scale));
-  height: calc(var(--slide-height) * var(--slide-scale));
-  flex-shrink: 0;
+  width: var(--slide-width);
+  height: var(--slide-height);
+  scale: var(--slide-scale, 1);
+  transform-origin: center center;
+  grid-area: 1 / 1;
   overflow: hidden;
 }
 
 ds-slide:not(.active) {
   display: none;
-}
-
-ds-slide > div.slide-container {
-  width: var(--slide-width);
-  height: var(--slide-height);
-  scale: var(--slide-scale);
-  transform-origin: 0 0;
 }

--- a/packages/framework/src/elements/slideshow.css
+++ b/packages/framework/src/elements/slideshow.css
@@ -1,17 +1,12 @@
 ds-slideshow {
-  --fit-scale: 1;
-
   position: relative;
   contain: layout style paint;
 
-  scale: var(--fit-scale);
   width: 100%;
   height: 100%;
 
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
+  display: grid;
+  place-content: center;
 
   font-family: var(--ds-font-content, system-ui, sans-serif);
   font-size: var(--ds-font-size-base, 1rem);


### PR DESCRIPTION
This PR fixes how slide content is scaled so that content is displayed at the same size regardless of the viewport size.